### PR TITLE
Fix bug with missing comment tags inside suspends

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRenderingSuspense-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingSuspense-test.js
@@ -71,6 +71,32 @@ describe('ReactDOMServer', () => {
       );
     });
 
+    it('should render sibling text nodes correctly inside suspends', async () => {
+      const suspenseCache = {};
+
+      const responsePromise = ReactDOMServer.renderToStringAsync(
+        <div>
+          <SuspenseCacheContext.Provider value={suspenseCache}>
+            <React.Suspense fallback="Loading">
+              <Suspender
+                suspendTo={
+                  <React.Fragment>
+                    {'a'} {'b'}
+                  </React.Fragment>
+                }
+              />
+            </React.Suspense>
+          </SuspenseCacheContext.Provider>
+        </div>,
+      );
+
+      const response = await responsePromise;
+
+      expect(response).toBe(
+        '<div data-reactroot=""><!--$--><p>a<!-- --> <!-- -->b</p><!--/$--></div>',
+      );
+    });
+
     it('should suspend in parallel within a single Suspense-boundary', async () => {
       const suspenseCache = {};
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1422,7 +1422,7 @@ class ReactDOMServerRenderer {
       props,
       namespace,
       this.makeStaticMarkup,
-      this.stack.length === 1,
+      this.stack.length === 1 && !this.isChildRenderer,
     );
     let footer = '';
     if (omittedCloseTags.hasOwnProperty(tag)) {
@@ -1594,7 +1594,7 @@ export class ReactDOMServerRendererAsync extends ReactDOMServerRenderer {
         return err.then(() => {
           const renderer = new ReactDOMServerRendererAsync(
             child,
-            true,
+            this.makeStaticMarkup,
             clonedRendererContext,
           );
           return renderer


### PR DESCRIPTION
Closes #7 

Turns out I had at some point mistakingly made every child renderer (which takes care of rendering a subtree that had previously suspended) render static markup which removes things like comment tags. This MR fixes that.