### PR TITLE
Fix broken build

### DIFF
--- a/packages/react-dom/npm/package.json
+++ b/packages/react-dom/npm/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "react-lightyear",
+  "version": "0.2.0",
+  "description": "React Server Renderer fork with support for Suspense.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ephem/react-lightyear.git",
+    "directory": "packages/react-dom"
+  },
+  "keywords": [
+    "react"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ephem/react-lightyear/issues"
+  },
+  "homepage": "https://github.com/ephem/react-lightyear",
+  "dependencies": {
+    "loose-envify": "^1.1.0",
+    "object-assign": "^4.1.1",
+    "prop-types": "^15.6.2",
+    "scheduler": "^0.13.6"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "16.8.6"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "server.js",
+    "server.node.js",
+    "cjs/"
+  ]
+}

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-lightyear",
-  "version": "0.2.0",
-  "description": "React Server Renderer fork with support for Suspense.",
+  "name": "react-dom",
+  "version": "16.8.6",
+  "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ephem/react-lightyear.git",
+    "url": "https://github.com/facebook/react.git",
     "directory": "packages/react-dom"
   },
   "keywords": [
@@ -13,9 +13,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ephem/react-lightyear/issues"
+    "url": "https://github.com/facebook/react/issues"
   },
-  "homepage": "https://github.com/ephem/react-lightyear",
+  "homepage": "https://reactjs.org/",
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
@@ -23,14 +23,33 @@
     "scheduler": "^0.13.6"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "16.8.6"
+    "react": "^16.0.0"
   },
   "files": [
     "LICENSE",
     "README.md",
+    "build-info.json",
+    "index.js",
+    "profiling.js",
     "server.js",
+    "server.browser.js",
     "server.node.js",
-    "cjs/"
-  ]
+    "test-utils.js",
+    "unstable-fire.js",
+    "unstable-fizz.js",
+    "unstable-fizz.browser.js",
+    "unstable-fizz.node.js",
+    "unstable-native-dependencies.js",
+    "cjs/",
+    "umd/"
+  ],
+  "browser": {
+    "./server.js": "./server.browser.js",
+    "./unstable-fizz.js": "./unstable-fizz.browser.js"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
+  }
 }


### PR DESCRIPTION
Build was broken for everyone except on my computer because of changes made to `packages/react-dom/package.json`.

This PR moves the `package.json` intended to use when publishing `react-lightyear` to npm into the `/npm`-folder, which gets copied on build. This fixes the broken build.