### PR TITLE
Fix context null bug (#22)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRenderingSuspense-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingSuspense-test.js
@@ -303,13 +303,16 @@ describe('ReactDOMServer', () => {
           <div>
             <TestContext.Provider value="Parent">
               <SuspenseCacheContext.Provider value={suspenseCache}>
+                <TestContext.Provider value="Earlier Sibling">
+                  <TestContextPrinter />
+                </TestContext.Provider>
                 <React.Suspense fallback="Loading">
                   <Suspender
                     suspendKey="1"
                     suspendTo={<TestContextPrinter />}
                   />
                 </React.Suspense>
-                <TestContext.Provider value="Sibling">
+                <TestContext.Provider value="Later Sibling">
                   <TestContextPrinter />
                 </TestContext.Provider>
               </SuspenseCacheContext.Provider>
@@ -317,7 +320,7 @@ describe('ReactDOMServer', () => {
           </div>,
         );
         expect(markup).toBe(
-          '<div data-reactroot=""><!--$--><p>Parent</p><!--/$-->Sibling</div>',
+          '<div data-reactroot="">Earlier Sibling<!--$--><p>Parent</p><!--/$-->Later Sibling</div>',
         );
       });
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1549,6 +1549,10 @@ export class ReactDOMServerRendererAsync extends ReactDOMServerRenderer {
       // this child renderer runs, we need to mutate them back
       // to what they should be
       for (let i = 0; i < this.contextStack.length; i += 1) {
+        // When contexts are popped, their value is set to null,
+        // when this happens, there also won't be a corresponding
+        // value in contextValues[i], so we just set that stack item
+        // to null entirely
         if (!this.contextStack[i]) {
           this.contextStack[i] = null;
         } else {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1549,14 +1549,18 @@ export class ReactDOMServerRendererAsync extends ReactDOMServerRenderer {
       // this child renderer runs, we need to mutate them back
       // to what they should be
       for (let i = 0; i < this.contextStack.length; i += 1) {
-        this.contextStack[i][this.threadID] = renderContext.contextValues[i];
+        if (!this.contextStack[i]) {
+          this.contextStack[i] = null;
+        } else {
+          this.contextStack[i][this.threadID] = renderContext.contextValues[i];
+        }
       }
     }
   }
 
   getClonedRenderContext() {
     const contextValues = this.contextStack.map(context => {
-      return context[this.threadID];
+      return !context ? context : context[this.threadID];
     });
 
     return {


### PR DESCRIPTION
Closes #22 

The `contextStack` can contain null values when contexts have been popped. The context cloning mechanism did not handle that properly which this PR fixes.