### PR TITLE
Flush early on suspend

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "version-check": "node ./scripts/tasks/version-check.js",
     "lightyear:build": "node ./scripts/rollup/build.js react-dom/server.node --type=NODE_DEV,NODE_PROD",
     "lightyear:test-watch": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js --watch",
-    "lightyear:test-watch-branch": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js --changedSince lightyear",
+    "lightyear:test-watch-branch": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js --changedSince lightyear --watch",
     "lightyear:test-changed": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js --changedSince lightyear",
     "lightyear:prettier-check": "node ./scripts/prettier/index.js check",
     "lightyear:prettier-check-changed": "node ./scripts/prettier/index.js check-changed",

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1479,6 +1479,12 @@ export default ReactDOMServerRenderer;
 function flattenAndResolveQueue(queue, bytes, cb) {
   if (queue[0][0].length < bytes && queue[0].length > 1) {
     if (queue[0][1].then) {
+      if (bytes !== Infinity && queue[0][0].length > 0) {
+        const result = queue[0][0];
+        queue[0][0] = '';
+        return cb(result);
+      }
+
       queue[0][1].then(markup => {
         queue[0][0] += markup;
         queue[0].splice(1, 1);
@@ -1489,15 +1495,13 @@ function flattenAndResolveQueue(queue, bytes, cb) {
       queue[0].splice(1, 1);
       flattenAndResolveQueue(queue, bytes, cb);
     }
+  } else if (queue[0].length === 1 && queue[0][0].length === 0) {
+    return cb('');
   } else {
-    if (queue[0].length === 1 && queue[0][0].length === 0) {
-      cb('');
-    }
-
     const result = queue[0][0];
     queue[0][0] = '';
 
-    cb(result);
+    return cb(result);
   }
 }
 


### PR DESCRIPTION
Closes #23 

When we are in streaming mode and a suspend happens, we want to ignore the desired number of bytes to read and just return what we have so this can be streamed to the client asap. This PR fixes that.

This also meant I could refactor the streaming tests to use the public API, be a lot more readable and not set a specific `highWaterMark` for the stream. This was a workaround to get the tests to work previously, and having to do this should have been a signal to me that something was wrong but I never caught that..

Huge thanks to @albertogasparin for finding and reporting this issue.