### PR TITLE
Add postinstall warning about non-semver package

### DIFF
--- a/packages/react-dom/npm/package.json
+++ b/packages/react-dom/npm/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/ephem/react-lightyear/issues"
   },
   "homepage": "https://github.com/ephem/react-lightyear",
+  "scripts": {
+    "postinstall": "echo '⚠️  Warning: react-lightyear does not follow semver, pin your version and read more in the FAQ:\n\nhttps://github.com/ThisIsMissEm/react-lightyear#how-does-the-versioning-work'"
+  },
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",

--- a/packages/react-dom/npm/package.json
+++ b/packages/react-dom/npm/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/ephem/react-lightyear",
   "scripts": {
-    "postinstall": "echo '⚠️  Warning: react-lightyear does not follow semver, pin your version and read more in the FAQ:\n\nhttps://github.com/ThisIsMissEm/react-lightyear#how-does-the-versioning-work'"
+    "postinstall": "echo '⚠️  Warning: react-lightyear does not follow semver, pin your version and read more in the FAQ:\n\nhttps://github.com/ephem/react-lightyear#how-does-the-versioning-work'"
   },
   "dependencies": {
     "loose-envify": "^1.1.0",


### PR DESCRIPTION
Hopefully, this will help users by notifying them that they should pin their react-lightyear versions due to react-lightyear not following semver.